### PR TITLE
Reduced Schedule

### DIFF
--- a/.github/workflows/update-tomcat-7.yml
+++ b/.github/workflows/update-tomcat-7.yml
@@ -1,7 +1,7 @@
 name: Update Tomcat 7
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-tomcat-8.yml
+++ b/.github/workflows/update-tomcat-8.yml
@@ -1,7 +1,7 @@
 name: Update Tomcat 8
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-tomcat-9.yml
+++ b/.github/workflows/update-tomcat-9.yml
@@ -1,7 +1,7 @@
 name: Update Tomcat 9
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-tomcat-access-logging-support.yml
+++ b/.github/workflows/update-tomcat-access-logging-support.yml
@@ -1,7 +1,7 @@
 name: Update tomcat-access-logging-support
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-tomcat-lifecycle-support.yml
+++ b/.github/workflows/update-tomcat-lifecycle-support.yml
@@ -1,7 +1,7 @@
 name: Update tomcat-lifecycle-support
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-tomcat-logging-support.yml
+++ b/.github/workflows/update-tomcat-logging-support.yml
@@ -1,7 +1,7 @@
 name: Update tomcat-logging-support
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:


### PR DESCRIPTION
Previously, the regularly scheduled builds exhausted the free tier of GitHub actions in some orgs.  This change reduces the number of hours and number of days that these scheduled events will run.