### PR TITLE
Exclude Main-Class WARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The Paketo Apache Tomcat Buildpack is a Cloud Native Buildpack that contributes 
 This buildpack will participate all the following conditions are met
 
 * `<APPLICATION_ROOT>/WEB-INF` exists
+* `Main-Class` is NOT defined in the mainfest
 
 The buildpack will do the following:
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/buildpacks/libcnb v1.18.1
 	github.com/heroku/color v0.0.6
 	github.com/onsi/gomega v1.10.3
+	github.com/paketo-buildpacks/libjvm v1.24.1
 	github.com/paketo-buildpacks/libpak v1.49.1
 	github.com/sclevine/spec v1.4.0
 )

--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/buildpacks/libcnb"
+	"github.com/paketo-buildpacks/libjvm"
 	"github.com/paketo-buildpacks/libpak"
 	"github.com/paketo-buildpacks/libpak/bard"
 )
@@ -32,6 +33,15 @@ type Build struct {
 }
 
 func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
+	m, err := libjvm.NewManifest(context.Application.Path)
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to read manifest\n%w", err)
+	}
+
+	if _, ok := m.Get("Main-Class"); ok {
+		return libcnb.BuildResult{}, nil
+	}
+
 	file := filepath.Join(context.Application.Path, "WEB-INF")
 	if _, err := os.Stat(file); err != nil && !os.IsNotExist(err) {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to stat file %s\n%w", file, err)

--- a/tomcat/build_test.go
+++ b/tomcat/build_test.go
@@ -48,6 +48,24 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(ctx.Application.Path)).To(Succeed())
 	})
 
+	it("does not contribute Tomcat if no WEB-INF", func() {
+		result, err := tomcat.Build{}.Build(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(result.Layers).To(BeEmpty())
+	})
+
+	it("does not contribute Tomcat if Main-Class", func() {
+		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "WEB-INF"), 0755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`Main-Class: test-main-class`), 0644)).To(Succeed())
+
+		result, err := tomcat.Build{}.Build(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(result.Layers).To(BeEmpty())
+	})
+
 	it("contributes Tomcat", func() {
 		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "WEB-INF"), 0755)).To(Succeed())
 

--- a/tomcat/detect_test.go
+++ b/tomcat/detect_test.go
@@ -50,6 +50,13 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.RemoveAll(path)).To(Succeed())
 	})
 
+	it("fails with Main-Class", func() {
+		Expect(os.MkdirAll(filepath.Join(path, "META-INF"), 0755)).To(Succeed())
+		Expect(ioutil.WriteFile(filepath.Join(path, "META-INF", "MANIFEST.MF"), []byte(`Main-Class: test-main-class`), 0644)).To(Succeed())
+
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{Pass: false}))
+	})
+
 	it("passes without WEB-INF", func() {
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
 			Pass: true,
@@ -63,6 +70,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			},
 		}))
 	})
+
 	it("passes with WEB-INF", func() {
 		Expect(os.MkdirAll(filepath.Join(path, "WEB-INF"), 0755)).To(Succeed())
 


### PR DESCRIPTION
Previously, whenever a WAR, built by Spring Boot was presented to this buildpack confusing things would happen.  The fact that the WAR file had both a WEB-INF/ directory (as all WAR files must) and a Main-Class declaration meant that how the WAR file would be run (via an external or embedded Tomcat) was confusing.

This change updates the detection logic so that Tomcat is only contributed if both the file is a WAR file and there is no Main-Class declared.

[spring-projects/spring-boot#23825]
