### PR TITLE
Require jvm-application-package in buildplan

### DIFF
--- a/tomcat/detect.go
+++ b/tomcat/detect.go
@@ -25,6 +25,12 @@ import (
 	"github.com/paketo-buildpacks/libjvm"
 )
 
+const (
+	PlanEntryJVMApplication        = "jvm-application"
+	PlanEntryJVMApplicationPackage = "jvm-application-package"
+	PlanEntryJRE                   = "jre"
+)
+
 type Detect struct{}
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
@@ -41,9 +47,13 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 		Pass: true,
 		Plans: []libcnb.BuildPlan{
 			{
+				Provides: []libcnb.BuildPlanProvide{
+					{Name: PlanEntryJVMApplication},
+				},
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-					{Name: "jvm-application"},
+					{Name: PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+					{Name: PlanEntryJVMApplicationPackage},
+					{Name: PlanEntryJVMApplication},
 				},
 			},
 		},
@@ -56,6 +66,6 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 		return result, nil
 	}
 
-	result.Plans[0].Provides = append(result.Plans[0].Provides, libcnb.BuildPlanProvide{Name: "jvm-application"})
+	result.Plans[0].Provides = append(result.Plans[0].Provides, libcnb.BuildPlanProvide{Name: PlanEntryJVMApplicationPackage})
 	return result, nil
 }

--- a/tomcat/detect_test.go
+++ b/tomcat/detect_test.go
@@ -57,36 +57,48 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{Pass: false}))
 	})
 
-	it("passes without WEB-INF", func() {
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-						{Name: "jvm-application"},
+	context("WEB-INF not found", func() {
+		it("requires jvm-application-artifact", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
 					},
 				},
-			},
-		}))
+			}))
+		})
 	})
 
-	it("passes with WEB-INF", func() {
-		Expect(os.MkdirAll(filepath.Join(path, "WEB-INF"), 0755)).To(Succeed())
+	context("WEB-INF found", func() {
+		it.Before(func() {
+			Expect(os.MkdirAll(filepath.Join(path, "WEB-INF"), 0755)).To(Succeed())
+		})
 
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "jvm-application"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
-						{Name: "jvm-application"},
+		it("requires and provides jvm-application-artifact", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+							{Name: "jvm-application-package"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+						},
 					},
 				},
-			},
-		}))
+			}))
+		})
 	})
 }


### PR DESCRIPTION
Previously we used the `jvm-application` build plan entry to represent two concepts.
1. package containing application bytecode
2. process types and configuration that will launch JVM application in the final image

This PR uses a new entry called `jvm-application-package` to represent application bytecode. Creating this distinction makes the role a given buildpack plays clearer and solves a practical problem. Previosly, when building from source code the jvm-application plan entry was being met by a build system buildpack (e.g. maven) and therefore not passed to buildpacks that contribute start commands (like apache-tomcat). Therefore, if a downstream buildpack wanted to add metadata to the `jvm-application` plan entry, intended to modify the behavior of a JVM application buildpack, that metadata would not be present if the image was built from source.

This depends on coordinated changes in the build system buildpacks.