### PR TITLE
Buildpack metadata updates

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-api = "0.5"
+api = "0.6"
 
 [buildpack]
 id       = "paketo-buildpacks/apache-tomcat"
 name     = "Paketo Apache Tomcat Buildpack"
 version  = "{{.version}}"
 homepage = "https://github.com/paketo-buildpacks/apache-tomcat"
+description = "A Cloud Native Buildpack that contributes Apache Tomcat and Process Types for WARs"
+keywords    = ["java", "tomcat", "war"]
+
+[[buildpack.licenses]]
+type = "Apache-2.0"
+uri  = "https://github.com/paketo-buildpacks/apache-tomcat/blob/main/LICENSE"
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,8 +5,13 @@ set -euo pipefail
 GOOS="linux" go build -ldflags='-s -w' -o bin/helper github.com/paketo-buildpacks/apache-tomcat/cmd/helper
 GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/apache-tomcat/cmd/main
 
-strip bin/helper bin/main
-upx -q -9 bin/helper bin/main
+if [ "${STRIP:-false}" != "false" ]; then
+  strip bin/helper bin/main
+fi
+
+if [ "${COMPRESS:-false}" != "false" ]; then
+  upx -q -9 bin/helper bin/main
+fi
 
 ln -fs main bin/build
 ln -fs main bin/detect

--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -63,7 +63,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result.Processes = append(result.Processes,
 		libcnb.Process{Type: "task", Command: command, Arguments: arguments},
 		libcnb.Process{Type: "tomcat", Command: command, Arguments: arguments},
-		libcnb.Process{Type: "web", Command: command, Arguments: arguments},
+		libcnb.Process{Type: "web", Command: command, Arguments: arguments, Default: true},
 	)
 
 	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &b.Logger)

--- a/tomcat/build_test.go
+++ b/tomcat/build_test.go
@@ -107,7 +107,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(result.Processes).To(ContainElements(
 			libcnb.Process{Type: "task", Command: "catalina.sh", Arguments: []string{"run"}},
 			libcnb.Process{Type: "tomcat", Command: "catalina.sh", Arguments: []string{"run"}},
-			libcnb.Process{Type: "web", Command: "catalina.sh", Arguments: []string{"run"}},
+			libcnb.Process{Type: "web", Command: "catalina.sh", Arguments: []string{"run"}, Default: true},
 		))
 
 		Expect(result.Layers).To(HaveLen(3))


### PR DESCRIPTION


<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Bump the lifecycle to 0.6, add a description, keywords and license metadata and make running 'upx' optional, default off in build script, and sets web as the default process type
## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
