### PR TITLE
Added syft scanning of the buildpack's catalina-base layer

### DIFF
--- a/tomcat/base.go
+++ b/tomcat/base.go
@@ -152,7 +152,7 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 				return libcnb.Layer{}, fmt.Errorf("unable to contribute external configuration\n%w", err)
 			}
 			if syftArtifact, err := b.ExternalConfigurationDependency.AsSyftArtifact(); err != nil {
-				return libcnb.Layer{}, fmt.Errorf("unable to write SBoM for dependency: %s, \n%w", b.ExternalConfigurationDependency.Name, err)
+				return libcnb.Layer{}, fmt.Errorf("unable to get Syft Artifact for dependency: %s, \n%w", b.ExternalConfigurationDependency.Name, err)
 			} else {
 				syftArtifacts = append(syftArtifacts, syftArtifact)
 			}

--- a/tomcat/base.go
+++ b/tomcat/base.go
@@ -142,7 +142,7 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to contribute logging\n%w", err)
 		}
 		if syftArtifact, err := b.LoggingDependency.AsSyftArtifact(); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to write SBoM for dependency: %s, \n%w", b.LoggingDependency.Name, err)
+			return libcnb.Layer{}, fmt.Errorf("unable to get Syft Artifact for dependency: %s, \n%w", b.LoggingDependency.Name, err)
 		} else {
 			syftArtifacts = append(syftArtifacts, syftArtifact)
 		}

--- a/tomcat/base.go
+++ b/tomcat/base.go
@@ -133,7 +133,7 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to contribute lifecycle\n%w", err)
 		}
 		if syftArtifact, err := b.LifecycleDependency.AsSyftArtifact(); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to write SBoM for dependency: %s, \n%w", b.LifecycleDependency.Name, err)
+			return libcnb.Layer{}, fmt.Errorf("unable to get Syft Artifact for dependency: %s, \n%w", b.LifecycleDependency.Name, err)
 		} else {
 			syftArtifacts = append(syftArtifacts, syftArtifact)
 		}

--- a/tomcat/base.go
+++ b/tomcat/base.go
@@ -124,7 +124,7 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 			return libcnb.Layer{}, fmt.Errorf("unable to contribute access logging\n%w", err)
 		}
 		if syftArtifact, err := b.AccessLoggingDependency.AsSyftArtifact(); err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to write SBoM for dependency: %s, \n%w", b.AccessLoggingDependency.Name, err)
+			return libcnb.Layer{}, fmt.Errorf("unable to get Syft Artifact for dependency: %s, \n%w", b.AccessLoggingDependency.Name, err)
 		} else {
 			syftArtifacts = append(syftArtifacts, syftArtifact)
 		}

--- a/tomcat/base_test.go
+++ b/tomcat/base_test.go
@@ -48,7 +48,6 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 
 		ctx.Layers.Path, err = ioutil.TempDir("", "base-layers")
 		Expect(err).NotTo(HaveOccurred())
-
 	})
 
 	it.After(func() {

--- a/tomcat/base_test.go
+++ b/tomcat/base_test.go
@@ -35,7 +35,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
-		ctx    libcnb.BuildContext
+		ctx libcnb.BuildContext
 	)
 
 	it.Before(func() {
@@ -92,9 +92,6 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 
 		dc := libpak.DependencyCache{CachePath: "testdata"}
 
-		layer, err := ctx.Layers.Layer("test-layer")
-		Expect(err).NotTo(HaveOccurred())
-
 		contributor, entries := tomcat.NewBase(
 			ctx.Application.Path,
 			ctx.Buildpack.Path,
@@ -107,6 +104,9 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			dc,
 		)
 		Expect(entries).To(HaveLen(0))
+
+		layer, err := ctx.Layers.Layer("test-layer")
+		Expect(err).NotTo(HaveOccurred())
 
 		layer, err = contributor.Contribute(layer)
 		Expect(err).NotTo(HaveOccurred())

--- a/tomcat/base_test.go
+++ b/tomcat/base_test.go
@@ -247,7 +247,6 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(filepath.Join(layer.Path, "fixture-marker")).To(BeARegularFile())
-
 		})
 	})
 

--- a/tomcat/base_test.go
+++ b/tomcat/base_test.go
@@ -34,8 +34,7 @@ import (
 func testBase(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
-
-		ctx libcnb.BuildContext
+		ctx    libcnb.BuildContext
 	)
 
 	it.Before(func() {
@@ -49,6 +48,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 
 		ctx.Layers.Path, err = ioutil.TempDir("", "base-layers")
 		Expect(err).NotTo(HaveOccurred())
+
 	})
 
 	it.After(func() {
@@ -92,6 +92,9 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 
 		dc := libpak.DependencyCache{CachePath: "testdata"}
 
+		layer, err := ctx.Layers.Layer("test-layer")
+		Expect(err).NotTo(HaveOccurred())
+
 		contributor, entries := tomcat.NewBase(
 			ctx.Application.Path,
 			ctx.Buildpack.Path,
@@ -104,9 +107,6 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			dc,
 		)
 		Expect(entries).To(HaveLen(0))
-
-		layer, err := ctx.Layers.Layer("test-layer")
-		Expect(err).NotTo(HaveOccurred())
 
 		layer, err = contributor.Contribute(layer)
 		Expect(err).NotTo(HaveOccurred())
@@ -247,6 +247,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(filepath.Join(layer.Path, "fixture-marker")).To(BeARegularFile())
+
 		})
 	})
 

--- a/tomcat/base_test.go
+++ b/tomcat/base_test.go
@@ -34,6 +34,7 @@ import (
 func testBase(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
+
 		ctx    libcnb.BuildContext
 	)
 

--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -66,6 +66,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	b.Logger.Title(context.Buildpack)
 
+	if b.SBOMScanner == nil {
+		b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
+	}
+
 	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &b.Logger)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
@@ -162,11 +166,8 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		libcnb.Process{Type: "web", Command: command, Arguments: arguments, Direct: true, Default: true},
 	)
 
-	if b.SBOMScanner == nil {
-		b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
-	}
 	if err := b.SBOMScanner.ScanLaunch(context.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON); err != nil {
-		return libcnb.BuildResult{}, fmt.Errorf("unable to create Build SBoM \n%w", err)
+		return libcnb.BuildResult{}, fmt.Errorf("unable to create Launch SBoM \n%w", err)
 	}
 
 	return result, nil

--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -66,10 +66,6 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	b.Logger.Title(context.Buildpack)
 
-	if b.SBOMScanner == nil {
-		b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
-	}
-
 	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &b.Logger)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
@@ -166,6 +162,9 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		libcnb.Process{Type: "web", Command: command, Arguments: arguments, Direct: true, Default: true},
 	)
 
+	if b.SBOMScanner == nil {
+		b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
+	}
 	if err := b.SBOMScanner.ScanLaunch(context.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON); err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create Launch SBoM \n%w", err)
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The catalina-base layer combines several dependencies together which were previously not being scanned. This adds scanning for this layer and it dependencies.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
