### PR TITLE
Removed warning for use of Tomcat 7

### DIFF
--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -88,10 +88,6 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
 	}
 
-	if strings.HasPrefix(tomcatDep.Version, "7") {
-		dc.Logger.Headerf("%s Apache Tomcat version 7 is End-of-Life, this is the last release that will contain version 7", color.YellowString("WARNING: "))
-	}
-
 	home, be := NewHome(tomcatDep, dc)
 	home.Logger = b.Logger
 	result.Layers = append(result.Layers, home)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Removed warning for use of Tomcat 7, as it is no longer provided and EOL.

## Use Cases
Fixes #160 

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
