### PR TITLE
Revert "Switch to new Apache Downloads CDN"

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -22,19 +22,19 @@ dependencies:
   version_pattern: "8\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
   with:
-    uri: https://downloads.apache.org/tomcat/tomcat-8
+    uri: https://archive.apache.org/dist/tomcat/tomcat-8
 - name:            Tomcat 9
   id:              tomcat
   version_pattern: "9\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
   with:
-    uri: https://downloads.apache.org/tomcat/tomcat-9
+    uri: https://archive.apache.org/dist/tomcat/tomcat-9
 - name:            Tomcat 10
   id:              tomcat
   version_pattern: "10\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
   with:
-    uri: https://downloads.apache.org/tomcat/tomcat-10
+    uri: https://archive.apache.org/dist/tomcat/tomcat-10
 - id:   tomcat-access-logging-support
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
   with:

--- a/.github/workflows/update-tomcat-10.yml
+++ b/.github/workflows/update-tomcat-10.yml
@@ -44,7 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
               with:
-                uri: https://downloads.apache.org/tomcat/tomcat-10
+                uri: https://archive.apache.org/dist/tomcat/tomcat-10
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-

--- a/.github/workflows/update-tomcat-8.yml
+++ b/.github/workflows/update-tomcat-8.yml
@@ -44,7 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
               with:
-                uri: https://downloads.apache.org/tomcat/tomcat-8
+                uri: https://archive.apache.org/dist/tomcat/tomcat-8
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-

--- a/.github/workflows/update-tomcat-9.yml
+++ b/.github/workflows/update-tomcat-9.yml
@@ -44,7 +44,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
               with:
-                uri: https://downloads.apache.org/tomcat/tomcat-9
+                uri: https://archive.apache.org/dist/tomcat/tomcat-9
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-


### PR DESCRIPTION
## Summary

This rolls back the change to use the new Apache Downloads CDN.

This was working well, but unfortunately, this new CDN only stores the latest release. Thus when a new Tomcat version is released, all the existing buildpacks would be broken. We need to use the Archives CDN as it stores all of the older versions as well.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
