### PR TITLE
Implements RFC 0008 & 'BP_JAVA_APP_SERVER' for Apache Tomcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # `gcr.io/paketo-buildpacks/apache-tomcat`
+
 The Paketo Apache Tomcat Buildpack is a Cloud Native Buildpack that contributes Apache Tomcat and Process Types for WARs.
 
 ## Behavior
-This buildpack will participate all the following conditions are met
 
+This buildpack will participate if all of the following conditions are met
+
+* `$BP_JAVA_APP_SERVER` is `tomcat` or if `$BP_JAVA_APP_SERVER` is unset or empty and this is the first buildpack to provide a Java application server.
 * `<APPLICATION_ROOT>/WEB-INF` exists
 * `Main-Class` is NOT defined in the manifest
 
@@ -30,15 +33,16 @@ When this buildpack runs on the [Tiny stack](https://paketo.io/docs/concepts/sta
 [lgs]: https://github.com/cloudfoundry/java-buildpack-support/tree/master/tomcat-logging-support
 
 ## Configuration
-| Environment Variable | Description
-| -------------------- | -----------
-| `$BP_TOMCAT_CONTEXT_PATH` | The context path to mount the application at.  Defaults to empty (`ROOT`).
-| `$BP_TOMCAT_EXT_CONF_SHA256` | The SHA256 hash of the external configuration package
-| `$BP_TOMCAT_EXT_CONF_STRIP` | The number of directory levels to strip from the external configuration package.  Defaults to `0`.
-| `$BP_TOMCAT_EXT_CONF_URI` | The download URI of the external configuration package
-| `$BP_TOMCAT_EXT_CONF_VERSION` | The version of the external configuration package
-| `$BP_TOMCAT_VERSION` |  Configure a specific Tomcat version.  This value must _exactly_ match a version available in the buildpack so typically it would configured to a wildcard such as `9.*`.
-| `BPL_TOMCAT_ACCESS_LOGGING_ENABLED` | Whether access logging should be activated.  Defaults to inactive.
+| Environment Variable                | Description                                                                                                                                                                                                    |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$BP_JAVA_APP_SERVER`               | The application server to use. It defaults to `` (empty string) which means that order dictates which Java application server is installed. The first Java application server buildpack to run will be picked. |
+| `$BP_TOMCAT_CONTEXT_PATH`           | The context path to mount the application at.  Defaults to empty (`ROOT`).                                                                                                                                     |
+| `$BP_TOMCAT_EXT_CONF_SHA256`        | The SHA256 hash of the external configuration package                                                                                                                                                          |
+| `$BP_TOMCAT_EXT_CONF_STRIP`         | The number of directory levels to strip from the external configuration package.  Defaults to `0`.                                                                                                             |
+| `$BP_TOMCAT_EXT_CONF_URI`           | The download URI of the external configuration package                                                                                                                                                         |
+| `$BP_TOMCAT_EXT_CONF_VERSION`       | The version of the external configuration package                                                                                                                                                              |
+| `$BP_TOMCAT_VERSION`                | Configure a specific Tomcat version.  This value must _exactly_ match a version available in the buildpack so typically it would configured to a wildcard such as `9.*`.                                       |
+| `BPL_TOMCAT_ACCESS_LOGGING_ENABLED` | Whether access logging should be activated.  Defaults to inactive.                                                                                                                                             |
 
 ### External Configuration Package
 The artifacts that the repository provides must be in TAR format and must follow the Tomcat archive structure:
@@ -56,9 +60,9 @@ The artifacts that the repository provides must be in TAR format and must follow
 The buildpack optionally accepts the following bindings:
 
 ### Type: `dependency-mapping`
-|Key                   | Value   | Description
-|----------------------|---------|------------
-|`<dependency-digest>` | `<uri>` | If needed, the buildpack will fetch the dependency with digest `<dependency-digest>` from `<uri>`
+| Key                   | Value   | Description                                                                                       |
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `<dependency-digest>` | `<uri>` | If needed, the buildpack will fetch the dependency with digest `<dependency-digest>` from `<uri>` |
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -43,6 +43,12 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
+    default = ""
+    description = "the application server to use"
+    name = "BP_JAVA_APP_SERVER"
+
+  [[metadata.configurations]]
+    build = true
     description = "the SHA256 hash of the external Tomcat configuration archive"
     name = "BP_TOMCAT_EXT_CONF_SHA256"
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -26,8 +26,10 @@ import (
 )
 
 func main() {
+	logger := bard.NewLogger(os.Stdout)
+
 	libpak.Main(
-		tomcat.Detect{},
-		tomcat.Build{Logger: bard.NewLogger(os.Stdout)},
+		tomcat.Detect{Logger: logger},
+		tomcat.Build{Logger: logger},
 	)
 }

--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -42,6 +42,7 @@ type Build struct {
 
 func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result := libcnb.NewBuildResult()
+
 	m, err := libjvm.NewManifest(context.Application.Path)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to read manifest\n%w", err)

--- a/tomcat/detect_test.go
+++ b/tomcat/detect_test.go
@@ -65,12 +65,14 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					{
 						Provides: []libcnb.BuildPlanProvide{
 							{Name: "jvm-application"},
+							{Name: "java-app-server"},
 						},
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: "syft"},
 							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
 							{Name: "jvm-application-package"},
 							{Name: "jvm-application"},
+							{Name: "java-app-server", Metadata: map[string]interface{}{"server": "tomcat"}},
 						},
 					},
 				},
@@ -90,6 +92,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					{
 						Provides: []libcnb.BuildPlanProvide{
 							{Name: "jvm-application"},
+							{Name: "java-app-server"},
 							{Name: "jvm-application-package"},
 						},
 						Requires: []libcnb.BuildPlanRequire{
@@ -97,10 +100,56 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
 							{Name: "jvm-application-package"},
 							{Name: "jvm-application"},
+							{Name: "java-app-server", Metadata: map[string]interface{}{"server": "tomcat"}},
 						},
 					},
 				},
 			}))
+		})
+	})
+
+	context("BP_JAVA_APP_SERVER is set to `tomcat`", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_JAVA_APP_SERVER", "tomcat")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_JAVA_APP_SERVER")).To(Succeed())
+		})
+
+		it("contributes Tomcat", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+				Pass: true,
+				Plans: []libcnb.BuildPlan{
+					{
+						Provides: []libcnb.BuildPlanProvide{
+							{Name: "jvm-application"},
+							{Name: "java-app-server"},
+						},
+						Requires: []libcnb.BuildPlanRequire{
+							{Name: "syft"},
+							{Name: "jre", Metadata: map[string]interface{}{"launch": true}},
+							{Name: "jvm-application-package"},
+							{Name: "jvm-application"},
+							{Name: "java-app-server", Metadata: map[string]interface{}{"server": "tomcat"}},
+						},
+					},
+				},
+			}))
+		})
+	})
+
+	context("BP_JAVA_APP_SERVER is set to `foo`", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_JAVA_APP_SERVER", "foo")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_JAVA_APP_SERVER")).To(Succeed())
+		})
+
+		it("fails", func() {
+			Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{Pass: false}))
 		})
 	})
 }


### PR DESCRIPTION
## Summary

This RFC implements RFC 0008 and adds support for 'BP_JAVA_APP_SERVER'. This enables the apache-tomcat buildpack to be used in conjunction with other App Server providing buildpacks.

https://github.com/paketo-buildpacks/rfcs/blob/main/text/java/0008-add-liberty-to-java-composite.md

**UPDATED** After some discussions, we've moved the logic for this check from build to detect. It simplifies things a bit and it has better handling for the case where a user enters `BP_JAVA_APP_SERVER=foo` and `foo` doesn't exist. For that case with the detect logic, detect will fail and you'll get a quick failure. With logic at build time, the individual builds will not do anything and you'll end up with a build that passes but does nothing (i.e. a broken image).

Testing this is a bit tricky because you need another buildpack that provides an app server. I was using a yet-to-be-merged PR with the liberty buildpack that implemented the same logic to test this. You also need a builder or composite buildpack because Apache Tomcat & the other Java app server buildpacks need to be marked as optional which you cannot do from the pack cli.

I used this sample builder:

```
description = "A sample Builder for using Java Apps Server related CNBs"

[[buildpacks]]
  id = "paketo-buildpacks/bellsoft-liberica"
  uri = "docker://gcr.io/paketo-buildpacks/bellsoft-liberica:9.2.0"

[[buildpacks]]
  id = "paketo-buildpacks/syft"
  uri = "docker://gcr.io/paketo-buildpacks/syft:1.9.0"

[[buildpacks]]
  id = "paketo-buildpacks/apache-tomcat"
  uri = "docker://docker.io/paketo-buildpacks/apache-tomcat:latest"

[[buildpacks]]
  id = "paketo-buildpacks/liberty"
  uri = "docker://docker.io/paketo-buildpacks/liberty:latest"

[[buildpacks]]
  id = "paketo-buildpacks/spring-boot"
  uri = "docker://gcr.io/paketo-buildpacks/spring-boot:5.6.1"

[[order]]

  [[order.group]]
    id = "paketo-buildpacks/bellsoft-liberica"

  [[order.group]]
    id = "paketo-buildpacks/syft"
    optional = true

  [[order.group]]
    id = "paketo-buildpacks/apache-tomcat"
    optional = true

  [[order.group]]
    id = "paketo-buildpacks/liberty"
    optional = true

  [[order.group]]
    id = "paketo-buildpacks/spring-boot"
    optional = true

[stack]
  build-image = "gcr.io/paketo-buildpacks/build:base-cnb"
  id = "io.buildpacks.stacks.bionic"
  run-image = "gcr.io/paketo-buildpacks/run:base-cnb"
```

This requires that you build and package the two sample buildpacks first.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
