### PR TITLE
Sets base and home layer paths group-writable

### DIFF
--- a/tomcat/base.go
+++ b/tomcat/base.go
@@ -116,6 +116,10 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 
 	return b.LayerContributor.Contribute(layer, func() (libcnb.Layer, error) {
 
+		if err := os.Chmod(filepath.Join(layer.Path), 0775); err != nil{
+			return  libcnb.Layer{}, fmt.Errorf("unable to set catalina base dir permissions\n%w", err)
+		}
+
 		if err := b.ContributeConfiguration(layer); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to contribute configuration\n%w", err)
 		}
@@ -164,7 +168,7 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		}
 
 		file = filepath.Join(layer.Path, "webapps")
-		if err := os.MkdirAll(file, 0755); err != nil {
+		if err := os.MkdirAll(file, 0775); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to create directory %s\n%w", file, err)
 		}
 
@@ -210,7 +214,7 @@ func (b Base) ContributeAccessLogging(layer libcnb.Layer) error {
 
 func (b Base) ContributeConfiguration(layer libcnb.Layer) error {
 	file := filepath.Join(layer.Path, "conf")
-	if err := os.MkdirAll(file, 0755); err != nil {
+	if err := os.MkdirAll(file, 0775); err != nil {
 		return fmt.Errorf("unable to create directory %s\n%w", file, err)
 	}
 
@@ -334,7 +338,7 @@ func (b Base) ContributeLogging(layer libcnb.Layer) error {
 	s := fmt.Sprintf(`CLASSPATH="%s"`, file)
 
 	file = filepath.Join(layer.Path, "bin", "setenv.sh")
-	if err = ioutil.WriteFile(file, []byte(s), 0755); err != nil {
+	if err = ioutil.WriteFile(file, []byte(s), 0775); err != nil {
 		return fmt.Errorf("unable to write file %s\n%w", file, err)
 	}
 

--- a/tomcat/home.go
+++ b/tomcat/home.go
@@ -19,6 +19,7 @@ package tomcat
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/libpak"
@@ -45,6 +46,9 @@ func (h Home) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		h.Logger.Bodyf("Expanding to %s", layer.Path)
 		if err := crush.ExtractTarGz(artifact, layer.Path, 1); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to expand Tomcat\n%w", err)
+		}
+		if err := os.Chmod(filepath.Join(layer.Path), 0775); err != nil{
+			return  libcnb.Layer{}, fmt.Errorf("unable to set catalina home dir permissions\n%w", err)
 		}
 
 		layer.LaunchEnvironment.Default("CATALINA_HOME", layer.Path)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Sets base and home layer paths group-writable to support running as non-default user with the Jammy stack 

Fixes #238 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
