### PR TITLE
Configure writable locations for logs and scratches when using Jammy builder

### DIFF
--- a/resources/server.xml
+++ b/resources/server.xml
@@ -24,9 +24,12 @@
             <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto'/>
             <Valve className='org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve'
                    pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i'
+                   directory='${java.io.tmpdir}/logs'
                    enabled='${access.logging.enabled}'/>
             <Host name='localhost'
-                  failCtxIfServletStartFails='true'>
+                  failCtxIfServletStartFails='true'
+                  createDirs='false'
+                  workDir='${java.io.tmpdir}/workDir'>
                 <Listener className='org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener'/>
                 <Valve className='org.apache.catalina.valves.ErrorReportValve' showReport='false' showServerInfo='false'/>
             </Host>

--- a/tomcat/base.go
+++ b/tomcat/base.go
@@ -180,6 +180,7 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		}
 
 		layer.LaunchEnvironment.Default("CATALINA_BASE", layer.Path)
+		layer.LaunchEnvironment.Default("CATALINA_TMPDIR", "/tmp")
 
 		if err := b.writeDependencySBOM(layer, syftArtifacts); err != nil {
 			return libcnb.Layer{}, err

--- a/tomcat/base.go
+++ b/tomcat/base.go
@@ -18,7 +18,6 @@ package tomcat
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -335,7 +334,7 @@ func (b Base) ContributeLogging(layer libcnb.Layer) error {
 	s := fmt.Sprintf(`CLASSPATH="%s"`, file)
 
 	file = filepath.Join(layer.Path, "bin", "setenv.sh")
-	if err = ioutil.WriteFile(file, []byte(s), 0755); err != nil {
+	if err = os.WriteFile(file, []byte(s), 0755); err != nil {
 		return fmt.Errorf("unable to write file %s\n%w", file, err)
 	}
 

--- a/tomcat/base_test.go
+++ b/tomcat/base_test.go
@@ -18,7 +18,6 @@ package tomcat_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,13 +40,13 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "base-application")
+		ctx.Application.Path, err = os.MkdirTemp("", "base-application")
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx.Buildpack.Path, err = ioutil.TempDir("", "base-buildpack")
+		ctx.Buildpack.Path, err = os.MkdirTemp("", "base-buildpack")
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "base-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "base-layers")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -59,13 +58,13 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 
 	it("contributes catalina base", func() {
 		Expect(os.MkdirAll(filepath.Join(ctx.Buildpack.Path, "resources"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
 			To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
 			To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
 			To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
 			To(Succeed())
 
 		accessLoggingDep := libpak.BuildpackDependency{
@@ -129,7 +128,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-access-logging-support.jar")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-lifecycle-support.jar")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "bin", "stub-tomcat-logging-support.jar")).To(BeARegularFile())
-		Expect(ioutil.ReadFile(filepath.Join(layer.Path, "bin", "setenv.sh"))).To(Equal(
+		Expect(os.ReadFile(filepath.Join(layer.Path, "bin", "setenv.sh"))).To(Equal(
 			[]byte(fmt.Sprintf(`CLASSPATH="%s"`, filepath.Join(layer.Path, "bin", "stub-tomcat-logging-support.jar")))))
 		Expect(layer.LaunchEnvironment["CATALINA_BASE.default"]).To(Equal(layer.Path))
 		Expect(filepath.Join(layer.Path, "temp")).To(BeADirectory())
@@ -146,13 +145,13 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 
 	it("contributes custom configuration", func() {
 		Expect(os.MkdirAll(filepath.Join(ctx.Buildpack.Path, "resources"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
 			To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
 			To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
 			To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
 			To(Succeed())
 
 		externalConfigurationDep := libpak.BuildpackDependency{
@@ -221,13 +220,13 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 
 		it("contributes custom configuration with directory", func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Buildpack.Path, "resources"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
 				To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
 				To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
 				To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
 				To(Succeed())
 
 			externalConfigurationDep := libpak.BuildpackDependency{
@@ -295,15 +294,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.Unsetenv("BP_TOMCAT_ENV_PROPERTY_SOURCE_DISABLED")).To(Succeed())
 		})
 
-	it("environment property source can be disabled", func() {
+		it("environment property source can be disabled", func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Buildpack.Path, "resources"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
 				To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
 				To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "server.xml"), []byte{}, 0644)).
 				To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
+			Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
 				To(Succeed())
 
 			accessLoggingDep := libpak.BuildpackDependency{
@@ -367,7 +366,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-access-logging-support.jar")).To(BeARegularFile())
 			Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-lifecycle-support.jar")).To(BeARegularFile())
 			Expect(filepath.Join(layer.Path, "bin", "stub-tomcat-logging-support.jar")).To(BeARegularFile())
-			Expect(ioutil.ReadFile(filepath.Join(layer.Path, "bin", "setenv.sh"))).To(Equal(
+			Expect(os.ReadFile(filepath.Join(layer.Path, "bin", "setenv.sh"))).To(Equal(
 				[]byte(fmt.Sprintf(`CLASSPATH="%s"`, filepath.Join(layer.Path, "bin", "stub-tomcat-logging-support.jar")))))
 			Expect(layer.LaunchEnvironment["CATALINA_BASE.default"]).To(Equal(layer.Path))
 			Expect(filepath.Join(layer.Path, "temp")).To(BeADirectory())

--- a/tomcat/build_test.go
+++ b/tomcat/build_test.go
@@ -17,7 +17,6 @@
 package tomcat_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,7 +40,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		ctx.Application.Path, err = ioutil.TempDir("", "tomcat-application")
+		ctx.Application.Path, err = os.MkdirTemp("", "tomcat-application")
 		Expect(err).NotTo(HaveOccurred())
 		ctx.Plan = libcnb.BuildpackPlan{Entries: []libcnb.BuildpackPlanEntry{
 			{Name: "jvm-application"},
@@ -69,7 +68,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it("does not contribute Tomcat if Main-Class", func() {
 		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "WEB-INF"), 0755)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`Main-Class: test-main-class`), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`Main-Class: test-main-class`), 0644)).To(Succeed())
 
 		result, err := tomcat.Build{SBOMScanner: &sbomScanner}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())

--- a/tomcat/detect_test.go
+++ b/tomcat/detect_test.go
@@ -17,7 +17,6 @@
 package tomcat_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		path, err = ioutil.TempDir("", "tomcat")
+		path, err = os.MkdirTemp("", "tomcat")
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx.Application.Path = path
@@ -52,7 +51,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	it("fails with Main-Class", func() {
 		Expect(os.MkdirAll(filepath.Join(path, "META-INF"), 0755)).To(Succeed())
-		Expect(ioutil.WriteFile(filepath.Join(path, "META-INF", "MANIFEST.MF"), []byte(`Main-Class: test-main-class`), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(path, "META-INF", "MANIFEST.MF"), []byte(`Main-Class: test-main-class`), 0644)).To(Succeed())
 
 		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{Pass: false}))
 	})

--- a/tomcat/home.go
+++ b/tomcat/home.go
@@ -43,7 +43,7 @@ func (h Home) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 
 	return h.LayerContributor.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
 		h.Logger.Bodyf("Expanding to %s", layer.Path)
-		if err := crush.ExtractTarGz(artifact, layer.Path, 1); err != nil {
+		if err := crush.Extract(artifact, layer.Path, 1); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to expand Tomcat\n%w", err)
 		}
 

--- a/tomcat/home_test.go
+++ b/tomcat/home_test.go
@@ -17,7 +17,6 @@
 package tomcat_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testHome(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "home-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "home-layers")
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
## Summary

Fixes #238 and replaces some deprecated API calls.

## Use Cases

Ensures that Tomcat is able to write logs and scratches when using the Jammy builder.

## Checklist

* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
