### PR TITLE
Add a Tomcat minor version regex

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -35,12 +35,14 @@ dependencies:
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
   with:
     uri: https://archive.apache.org/dist/tomcat/tomcat-10
+    version_regex: "(10)\\.(0)\\.[\\d]+"
 - name:            Tomcat 10.1
   id:              tomcat
   version_pattern: "10\\.1\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
   with:
     uri: https://archive.apache.org/dist/tomcat/tomcat-10
+    version_regex: "(10)\\.(1)\\.[\\d]+"
 - id:   tomcat-access-logging-support
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
   with:

--- a/.github/workflows/pb-update-tomcat-10-1.yml
+++ b/.github/workflows/pb-update-tomcat-10-1.yml
@@ -45,6 +45,7 @@ jobs:
               uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
               with:
                 uri: https://archive.apache.org/dist/tomcat/tomcat-10
+                version_regex: (10)\.(1)\.[\d]+
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-

--- a/.github/workflows/pb-update-tomcat-10.yml
+++ b/.github/workflows/pb-update-tomcat-10.yml
@@ -45,6 +45,7 @@ jobs:
               uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
               with:
                 uri: https://archive.apache.org/dist/tomcat/tomcat-10
+                version_regex: (10)\.(0)\.[\d]+
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-


### PR DESCRIPTION
Requires [PR 855](https://github.com/paketo-buildpacks/pipeline-builder/pull/855) to be merged and the new action to be published (happens automatically when PR is merged).

This should fix the issue on PR 262.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
