### PR TITLE
Use /tmp for tiny stack as temp folder

### DIFF
--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -204,7 +204,6 @@ func (b Build) tinyStartCommand(homePath, basePath string, loggingDep libpak.Bui
 	arguments = append(arguments,
 		fmt.Sprintf("-Dcatalina.home=%s", homePath),
 		fmt.Sprintf("-Dcatalina.base=%s", basePath),
-		fmt.Sprintf("-Djava.io.tmpdir=%s", filepath.Join(basePath, "/temp")),
 		"org.apache.catalina.startup.Bootstrap", "start",
 	)
 

--- a/tomcat/build_test.go
+++ b/tomcat/build_test.go
@@ -251,7 +251,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					"catalina-base/bin/tomcat-logging-support-1.1.1.RELEASE.jar:tomcat/bin/bootstrap.jar:tomcat/bin/tomcat-juli.jar",
 					"-Dcatalina.home=tomcat",
 					"-Dcatalina.base=catalina-base",
-					"-Djava.io.tmpdir=catalina-base/temp",
 					"org.apache.catalina.startup.Bootstrap",
 					"start",
 				},


### PR DESCRIPTION
fixes #279 

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Do not set `java.io.tmpdir` for the tiny stack, but rely on the default `/tmp`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
With that change, it is possible to mount a readonly root filesystem as long as `/tmp` is writeable.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
