### PR TITLE
Fix failures with updating tomcat support dependencies

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -49,15 +49,18 @@ dependencies:
     uri:         https://repo.spring.io/release
     group_id:    org.cloudfoundry
     artifact_id: tomcat-access-logging-support
+    version_regex: "^[\\d]+\\.[\\d]+\\.[\\d]+\\.RELEASE$"
 - id:   tomcat-lifecycle-support
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
   with:
     uri:         https://repo.spring.io/release
     group_id:    org.cloudfoundry
     artifact_id: tomcat-lifecycle-support
+    version_regex: "^[\\d]+\\.[\\d]+\\.[\\d]+\\.RELEASE$"
 - id:   tomcat-logging-support
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
   with:
     uri:         https://repo.spring.io/release
     group_id:    org.cloudfoundry
     artifact_id: tomcat-logging-support
+    version_regex: "^[\\d]+\\.[\\d]+\\.[\\d]+\\.RELEASE$"

--- a/.github/workflows/pb-update-tomcat-access-logging-support.yml
+++ b/.github/workflows/pb-update-tomcat-access-logging-support.yml
@@ -47,6 +47,7 @@ jobs:
                 artifact_id: tomcat-access-logging-support
                 group_id: org.cloudfoundry
                 uri: https://repo.spring.io/release
+                version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-

--- a/.github/workflows/pb-update-tomcat-lifecycle-support.yml
+++ b/.github/workflows/pb-update-tomcat-lifecycle-support.yml
@@ -47,6 +47,7 @@ jobs:
                 artifact_id: tomcat-lifecycle-support
                 group_id: org.cloudfoundry
                 uri: https://repo.spring.io/release
+                version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-

--- a/.github/workflows/pb-update-tomcat-logging-support.yml
+++ b/.github/workflows/pb-update-tomcat-logging-support.yml
@@ -47,6 +47,7 @@ jobs:
                 artifact_id: tomcat-logging-support
                 group_id: org.cloudfoundry
                 uri: https://repo.spring.io/release
+                version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack
               run: |-


### PR DESCRIPTION
## Summary

Should fix failures like [this](https://github.com/paketo-buildpacks/apache-tomcat/actions/runs/3537930601) and [this](https://github.com/paketo-buildpacks/apache-tomcat/actions/runs/3537906678).

## Use Cases

Fix CI failures.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
