### PR TITLE
Use current time as version in external configuration layer

### DIFF
--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -129,7 +129,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 		if !versionExists && !shaExists {
 			v = time.Now().Format(time.RFC3339)
-			b.Logger.Infof("No BP_TOMCAT_EXT_CONF_VERSION or BP_TOMCAT_EXT_CONF_SHA256 provided, using version '%s'", v)
+			b.Logger.Infof(color.YellowString("WARNING: No BP_TOMCAT_EXT_CONF_VERSION or BP_TOMCAT_EXT_CONF_SHA256 provided, so no layer caching will occur."))
 		}
 
 		externalConfigurationDependency = &libpak.BuildpackDependency{

--- a/tomcat/build.go
+++ b/tomcat/build.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/paketo-buildpacks/libpak/effect"
 	"github.com/paketo-buildpacks/libpak/sbom"
@@ -123,8 +124,13 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	var externalConfigurationDependency *libpak.BuildpackDependency
 	if uri, ok := cr.Resolve("BP_TOMCAT_EXT_CONF_URI"); ok {
-		v, _ := cr.Resolve("BP_TOMCAT_EXT_CONF_VERSION")
-		s, _ := cr.Resolve("BP_TOMCAT_EXT_CONF_SHA256")
+		v, versionExists := cr.Resolve("BP_TOMCAT_EXT_CONF_VERSION")
+		s, shaExists := cr.Resolve("BP_TOMCAT_EXT_CONF_SHA256")
+
+		if !versionExists && !shaExists {
+			v = time.Now().Format(time.RFC3339)
+			b.Logger.Infof("No BP_TOMCAT_EXT_CONF_VERSION or BP_TOMCAT_EXT_CONF_SHA256 provided, using version '%s'", v)
+		}
 
 		externalConfigurationDependency = &libpak.BuildpackDependency{
 			ID:      "tomcat-external-configuration",

--- a/tomcat/build_test.go
+++ b/tomcat/build_test.go
@@ -370,15 +370,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}
 			ctx.StackID = "test-stack-id"
 
-			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_SHA256", "test-sha256")).To(Succeed())
-			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_URI", "test-uri")).To(Succeed())
-			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_VERSION", "test-version")).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_SHA256")).To(Succeed())
-			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_URI")).To(Succeed())
-			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_VERSION")).To(Succeed())
+			t.Setenv("BP_TOMCAT_EXT_CONF_SHA256", "test-sha256")
+			t.Setenv("BP_TOMCAT_EXT_CONF_URI", "test-uri")
+			t.Setenv("BP_TOMCAT_EXT_CONF_VERSION", "test-version")
 		})
 
 		it("contributes external configuration when $BP_TOMCAT_EXT_CONF_URI, $BP_TOMCAT_EXT_CONF_VERSION and $BP_TOMCAT_EXT_CONF_SHA256 are set", func() {

--- a/tomcat/build_test.go
+++ b/tomcat/build_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/paketo-buildpacks/libpak/sbom/mocks"
 
@@ -341,18 +342,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("$BP_TOMCAT_EXT_CONF_URI", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_SHA256", "test-sha256")).To(Succeed())
-			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_URI", "test-uri")).To(Succeed())
-			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_VERSION", "test-version")).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_SHA256")).To(Succeed())
-			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_URI")).To(Succeed())
-			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_VERSION")).To(Succeed())
-		})
-
-		it("contributes external configuration when $BP_TOMCAT_EXT_CONF_URI is set", func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "WEB-INF"), 0755)).To(Succeed())
 
 			ctx.Buildpack.Metadata = map[string]interface{}{
@@ -381,9 +370,22 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}
 			ctx.StackID = "test-stack-id"
 
+			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_SHA256", "test-sha256")).To(Succeed())
+			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_URI", "test-uri")).To(Succeed())
+			Expect(os.Setenv("BP_TOMCAT_EXT_CONF_VERSION", "test-version")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_SHA256")).To(Succeed())
+			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_URI")).To(Succeed())
+			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_VERSION")).To(Succeed())
+		})
+
+		it("contributes external configuration when $BP_TOMCAT_EXT_CONF_URI, $BP_TOMCAT_EXT_CONF_VERSION and $BP_TOMCAT_EXT_CONF_SHA256 are set", func() {
 			result, err := tomcat.Build{SBOMScanner: &sbomScanner}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
+			Expect(result.Layers).To(HaveLen(3))
 			Expect(result.Layers[2].(tomcat.Base).ExternalConfigurationDependency).To(Equal(&libpak.BuildpackDependency{
 				ID:      "tomcat-external-configuration",
 				Name:    "Tomcat External Configuration",
@@ -394,6 +396,55 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}))
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
 		})
+
+		it("uses time as version if neither $BP_TOMCAT_EXT_CONF_VERSION nor $BP_TOMCAT_EXT_CONF_SHA256 is provided", func() {
+			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_SHA256")).To(Succeed())
+			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_VERSION")).To(Succeed())
+
+			result, err := tomcat.Build{SBOMScanner: &sbomScanner}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers).To(HaveLen(3))
+			version := result.Layers[2].(tomcat.Base).ExternalConfigurationDependency.Version
+			Expect(time.Parse(time.RFC3339, version)).NotTo(BeNil())
+		})
+
+		it("contributes external configuration when $BP_TOMCAT_EXT_CONF_URI and $BP_TOMCAT_EXT_CONF_VERSION are set", func() {
+			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_SHA256")).To(Succeed())
+
+			result, err := tomcat.Build{SBOMScanner: &sbomScanner}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers).To(HaveLen(3))
+			Expect(result.Layers[2].(tomcat.Base).ExternalConfigurationDependency).To(Equal(&libpak.BuildpackDependency{
+				ID:      "tomcat-external-configuration",
+				Name:    "Tomcat External Configuration",
+				Version: "test-version",
+				URI:     "test-uri",
+				SHA256:  "",
+				Stacks:  []string{ctx.StackID},
+			}))
+			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
+		})
+
+		it("contributes external configuration when $BP_TOMCAT_EXT_CONF_URI and $BP_TOMCAT_EXT_CONF_SHA256 are set", func() {
+			Expect(os.Unsetenv("BP_TOMCAT_EXT_CONF_VERSION")).To(Succeed())
+
+			result, err := tomcat.Build{SBOMScanner: &sbomScanner}.Build(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Layers).To(HaveLen(3))
+			Expect(result.Layers[2].(tomcat.Base).ExternalConfigurationDependency).To(Equal(&libpak.BuildpackDependency{
+				ID:      "tomcat-external-configuration",
+				Name:    "Tomcat External Configuration",
+				Version: "",
+				URI:     "test-uri",
+				SHA256:  "test-sha256",
+				Stacks:  []string{ctx.StackID},
+			}))
+			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
+		})
+
 	})
 
 	it("returns default context path", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Fixes #286 


## Use Cases
<!-- An explanation of the use cases your change enables -->
If neither `version` nor `sha` is provided, the external configuration should never be reused from layer cache since the external configuration could have changed.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
