### PR TITLE
Changed Maven depedency source to Maven Central

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -46,21 +46,21 @@ dependencies:
 - id:   tomcat-access-logging-support
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
   with:
-    uri:         https://repo.spring.io/release
+    uri:         https://repo1.maven.org/maven2
     group_id:    org.cloudfoundry
     artifact_id: tomcat-access-logging-support
     version_regex: "^[\\d]+\\.[\\d]+\\.[\\d]+\\.RELEASE$"
 - id:   tomcat-lifecycle-support
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
   with:
-    uri:         https://repo.spring.io/release
+    uri:         https://repo1.maven.org/maven2
     group_id:    org.cloudfoundry
     artifact_id: tomcat-lifecycle-support
     version_regex: "^[\\d]+\\.[\\d]+\\.[\\d]+\\.RELEASE$"
 - id:   tomcat-logging-support
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main
   with:
-    uri:         https://repo.spring.io/release
+    uri:         https://repo1.maven.org/maven2
     group_id:    org.cloudfoundry
     artifact_id: tomcat-logging-support
     version_regex: "^[\\d]+\\.[\\d]+\\.[\\d]+\\.RELEASE$"

--- a/.github/workflows/pb-update-tomcat-access-logging-support.yml
+++ b/.github/workflows/pb-update-tomcat-access-logging-support.yml
@@ -46,7 +46,7 @@ jobs:
               with:
                 artifact_id: tomcat-access-logging-support
                 group_id: org.cloudfoundry
-                uri: https://repo.spring.io/release
+                uri: https://repo1.maven.org/maven2
                 version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/pb-update-tomcat-lifecycle-support.yml
+++ b/.github/workflows/pb-update-tomcat-lifecycle-support.yml
@@ -46,7 +46,7 @@ jobs:
               with:
                 artifact_id: tomcat-lifecycle-support
                 group_id: org.cloudfoundry
-                uri: https://repo.spring.io/release
+                uri: https://repo1.maven.org/maven2
                 version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/pb-update-tomcat-logging-support.yml
+++ b/.github/workflows/pb-update-tomcat-logging-support.yml
@@ -46,7 +46,7 @@ jobs:
               with:
                 artifact_id: tomcat-logging-support
                 group_id: org.cloudfoundry
-                uri: https://repo.spring.io/release
+                uri: https://repo1.maven.org/maven2
                 version_regex: ^[\d]+\.[\d]+\.[\d]+\.RELEASE$
             - name: Update Buildpack Dependency
               id: buildpack


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Fixes #295 - due to changes to permissions on repo.spring.io access, this PR changes the URI for the dependency for Tomcat Support Jars to Maven Central.

This will only ensure the next release of the Apache Tomcat buildpack resolves the Tomcat Support dependencies successfully. Users will need to ensure they use the latest version of this buildpack and the [Java](https://github.com/paketo-buildpacks/java) composite buildpack(s) that include it, to prevent failing builds due to #295 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
