### PR TITLE
Adds detection logging messages at info level

### DIFF
--- a/tomcat/detect.go
+++ b/tomcat/detect.go
@@ -48,7 +48,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 
 	appServer, _ := cr.Resolve("BP_JAVA_APP_SERVER")
 	if appServer != "" && appServer != JavaAppServerTomcat {
-		d.Logger.Debugf("failed to match requested app server of [%s], buildpack supports [%s]", appServer, JavaAppServerTomcat)
+		d.Logger.Infof("SKIPPED: buildpack does not match requested app server of [%s], buildpack supports [%s]", appServer, JavaAppServerTomcat)
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 
@@ -58,6 +58,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 	}
 
 	if _, ok := m.Get("Main-Class"); ok {
+		d.Logger.Info("SKIPPED: Manifest attribute 'Main-Class' was found")
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 

--- a/tomcat/detect.go
+++ b/tomcat/detect.go
@@ -41,7 +41,7 @@ type Detect struct {
 }
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
-	cr, err := libpak.NewConfigurationResolver(context.Buildpack, nil)
+	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &d.Logger)
 	if err != nil {
 		return libcnb.DetectResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
 	}
@@ -85,6 +85,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 	if _, err := os.Stat(file); err != nil && !os.IsNotExist(err) {
 		return libcnb.DetectResult{}, fmt.Errorf("unable to stat file %s\n%w", file, err)
 	} else if os.IsNotExist(err) {
+		d.Logger.Info("PASSED: a WEB-INF directory was not found, this is normal when building from source")
 		return result, nil
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR adds additional logging when Detect returns false for this buildpack. This is to provide more information about why the detection failed for this buildpack when verbose/debug logging is enabled. 

As of lifecycle v1.16.0, if the detect phase fails as a whole, log messages are printed at info level by default, without the need for the verbose flag.

## Use Cases
A `pack build` command with the `--verbose` flag set will show these log statement if detection fails. If Detect succeeds, the output is not shown unless `--verbose` is set.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
