### PR TITLE
feat: add support for multiple war files

### DIFF
--- a/tomcat/detect.go
+++ b/tomcat/detect.go
@@ -88,7 +88,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 	file := filepath.Join(context.Application.Path, "WEB-INF")
 	if _, err := os.Stat(file); err != nil && !os.IsNotExist(err) {
 		return libcnb.DetectResult{}, fmt.Errorf("unable to stat file %s\n%w", file, err)
-	} else if os.IsNotExist(err) {
+	} else if os.IsNotExist(err) && !warFilesExist {
 		d.Logger.Info("PASSED: a WEB-INF directory was not found, this is normal when building from source")
 		return result, nil
 	}

--- a/tomcat/detect_test.go
+++ b/tomcat/detect_test.go
@@ -187,6 +187,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Provides: []libcnb.BuildPlanProvide{
 							{Name: "jvm-application"},
 							{Name: "java-app-server"},
+							{Name: "jvm-application-package"},
 						},
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: "syft"},


### PR DESCRIPTION
Closes: https://github.com/paketo-buildpacks/apache-tomcat/issues/134

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change adds support to pack multiple precompiled war files

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
