### PR TITLE
Introduce mechanism to specify additional locations for the common cl…

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,7 +28,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/apache-tomcat/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/main", "linux/amd64/bin/helper", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/main", "linux/arm64/bin/helper", "buildpack.toml", "resources/context.xml", "resources/logging.properties", "resources/server.xml", "resources/web.xml"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/main", "linux/amd64/bin/helper", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/main", "linux/arm64/bin/helper", "buildpack.toml", "resources/tomcat9/catalina.properties", "resources/tomcat10/catalina.properties", "resources/tomcat11/catalina.properties", "resources/context.xml", "resources/logging.properties", "resources/server.xml", "resources/web.xml"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]

--- a/resources/tomcat10/catalina.properties
+++ b/resources/tomcat10/catalina.properties
@@ -1,0 +1,223 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageAccess unless the
+# corresponding RuntimePermission ("accessClassInPackage."+package) has
+# been granted.
+package.access=sun.,org.apache.catalina.,org.apache.coyote.,org.apache.jasper.,org.apache.tomcat.
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageDefinition unless the
+# corresponding RuntimePermission ("defineClassInPackage."+package) has
+# been granted.
+#
+# by default, no packages are restricted for definition, and none of
+# the class loaders supplied with the JDK call checkPackageDefinition.
+#
+package.definition=sun.,java.,org.apache.catalina.,org.apache.coyote.,\
+org.apache.jasper.,org.apache.naming.,org.apache.tomcat.
+
+#
+#
+# List of comma-separated paths defining the contents of the "common"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank,the JVM system loader will be used as Catalina's "common"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values are enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+common.loader=${ADD_TO_COMMON_LOADER},"${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar"
+
+#
+# List of comma-separated paths defining the contents of the "server"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank, the "common" loader will be used as Catalina's "server"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+server.loader=
+
+#
+# List of comma-separated paths defining the contents of the "shared"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_BASE path or absolute. If left as blank,
+# the "common" loader will be used as Catalina's "shared" loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+# Please note that for single jars, e.g. bar.jar, you need the URL form
+# starting with file:.
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+shared.loader=
+
+# Default list of JAR files that should not be scanned using the JarScanner
+# functionality. This is typically used to scan JARs for configuration
+# information. JARs that do not contain such information may be excluded from
+# the scan to speed up the scanning process. This is the default list. JARs on
+# this list are excluded from all scans. The list must be a comma separated list
+# of JAR file names.
+# The list of JARs to skip may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+# The JARs listed below include:
+# - Tomcat Bootstrap JARs
+# - Tomcat API JARs
+# - Catalina JARs
+# - Jasper JARs
+# - Tomcat JARs
+# - Common non-Tomcat JARs
+# - Test JARs (JUnit, Cobertura and dependencies)
+tomcat.util.scan.StandardJarScanFilter.jarsToSkip=\
+annotations-api.jar,\
+ant-junit*.jar,\
+ant-launcher*.jar,\
+ant*.jar,\
+asm-*.jar,\
+aspectj*.jar,\
+bcel*.jar,\
+biz.aQute.bnd*.jar,\
+bootstrap.jar,\
+catalina-ant.jar,\
+catalina-ha.jar,\
+catalina-ssi.jar,\
+catalina-storeconfig.jar,\
+catalina-tribes.jar,\
+catalina.jar,\
+cglib-*.jar,\
+cobertura-*.jar,\
+commons-beanutils*.jar,\
+commons-codec*.jar,\
+commons-collections*.jar,\
+commons-compress*.jar,\
+commons-daemon.jar,\
+commons-dbcp*.jar,\
+commons-digester*.jar,\
+commons-fileupload*.jar,\
+commons-httpclient*.jar,\
+commons-io*.jar,\
+commons-lang*.jar,\
+commons-logging*.jar,\
+commons-math*.jar,\
+commons-pool*.jar,\
+derby-*.jar,\
+dom4j-*.jar,\
+easymock-*.jar,\
+ecj-*.jar,\
+el-api.jar,\
+geronimo-spec-jaxrpc*.jar,\
+h2*.jar,\
+ha-api-*.jar,\
+hamcrest-*.jar,\
+hibernate*.jar,\
+httpclient*.jar,\
+icu4j-*.jar,\
+jakartaee-migration-*.jar,\
+jasper-el.jar,\
+jasper.jar,\
+jaspic-api.jar,\
+jaxb-*.jar,\
+jaxen-*.jar,\
+jaxws-rt-*.jar,\
+jdom-*.jar,\
+jetty-*.jar,\
+jmx-tools.jar,\
+jmx.jar,\
+jsp-api.jar,\
+jstl.jar,\
+jta*.jar,\
+junit-*.jar,\
+junit.jar,\
+log4j*.jar,\
+mail*.jar,\
+objenesis-*.jar,\
+oraclepki.jar,\
+org.hamcrest.core_*.jar,\
+org.junit_*.jar,\
+oro-*.jar,\
+servlet-api-*.jar,\
+servlet-api.jar,\
+slf4j*.jar,\
+taglibs-standard-spec-*.jar,\
+tagsoup-*.jar,\
+tomcat-api.jar,\
+tomcat-coyote.jar,\
+tomcat-coyote-ffm.jar,\
+tomcat-dbcp.jar,\
+tomcat-i18n-*.jar,\
+tomcat-jdbc.jar,\
+tomcat-jni.jar,\
+tomcat-juli-adapters.jar,\
+tomcat-juli.jar,\
+tomcat-util-scan.jar,\
+tomcat-util.jar,\
+tomcat-websocket.jar,\
+tools.jar,\
+unboundid-ldapsdk-*.jar,\
+websocket-api.jar,\
+websocket-client-api.jar,\
+wsdl4j*.jar,\
+xercesImpl.jar,\
+xml-apis.jar,\
+xmlParserAPIs-*.jar,\
+xmlParserAPIs.jar,\
+xom-*.jar
+
+# Default list of JAR files that should be scanned that overrides the default
+# jarsToSkip list above. This is typically used to include a specific JAR that
+# has been excluded by a broad file name pattern in the jarsToSkip list.
+# The list of JARs to scan may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+tomcat.util.scan.StandardJarScanFilter.jarsToScan=\
+log4j-taglib*.jar,\
+log4j-jakarta-web*.jar,\
+log4javascript*.jar,\
+slf4j-taglib*.jar
+
+# String cache configuration.
+tomcat.util.buf.StringCache.byte.enabled=true
+#tomcat.util.buf.StringCache.char.enabled=true
+#tomcat.util.buf.StringCache.trainThreshold=500000
+#tomcat.util.buf.StringCache.cacheSize=5000
+
+# Disable use of some privilege blocks Tomcat doesn't need since calls to the
+# code in question are always already inside a privilege block
+org.apache.el.GET_CLASSLOADER_USE_PRIVILEGED=false
+

--- a/resources/tomcat11/catalina.properties
+++ b/resources/tomcat11/catalina.properties
@@ -1,0 +1,199 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+#
+# List of comma-separated paths defining the contents of the "common"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank,the JVM system loader will be used as Catalina's "common"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values are enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+common.loader=${ADD_TO_COMMON_LOADER},"${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar"
+
+#
+# List of comma-separated paths defining the contents of the "server"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank, the "common" loader will be used as Catalina's "server"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+server.loader=
+
+#
+# List of comma-separated paths defining the contents of the "shared"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_BASE path or absolute. If left as blank,
+# the "common" loader will be used as Catalina's "shared" loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+# Please note that for single jars, e.g. bar.jar, you need the URL form
+# starting with file:.
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+shared.loader=
+
+# Default list of JAR files that should not be scanned using the JarScanner
+# functionality. This is typically used to scan JARs for configuration
+# information. JARs that do not contain such information may be excluded from
+# the scan to speed up the scanning process. This is the default list. JARs on
+# this list are excluded from all scans. The list must be a comma separated list
+# of JAR file names.
+# The list of JARs to skip may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+# The JARs listed below include:
+# - Tomcat Bootstrap JARs
+# - Tomcat API JARs
+# - Catalina JARs
+# - Jasper JARs
+# - Tomcat JARs
+# - Common non-Tomcat JARs
+# - Test JARs (JUnit, Cobertura and dependencies)
+tomcat.util.scan.StandardJarScanFilter.jarsToSkip=\
+annotations-api.jar,\
+ant-junit*.jar,\
+ant-launcher*.jar,\
+ant*.jar,\
+asm-*.jar,\
+aspectj*.jar,\
+bcel*.jar,\
+biz.aQute.bnd*.jar,\
+bootstrap.jar,\
+catalina-ant.jar,\
+catalina-ha.jar,\
+catalina-ssi.jar,\
+catalina-storeconfig.jar,\
+catalina-tribes.jar,\
+catalina.jar,\
+cglib-*.jar,\
+cobertura-*.jar,\
+commons-beanutils*.jar,\
+commons-codec*.jar,\
+commons-collections*.jar,\
+commons-compress*.jar,\
+commons-daemon.jar,\
+commons-dbcp*.jar,\
+commons-digester*.jar,\
+commons-fileupload*.jar,\
+commons-httpclient*.jar,\
+commons-io*.jar,\
+commons-lang*.jar,\
+commons-logging*.jar,\
+commons-math*.jar,\
+commons-pool*.jar,\
+derby-*.jar,\
+dom4j-*.jar,\
+easymock-*.jar,\
+ecj-*.jar,\
+el-api.jar,\
+geronimo-spec-jaxrpc*.jar,\
+h2*.jar,\
+ha-api-*.jar,\
+hamcrest-*.jar,\
+hibernate*.jar,\
+httpclient*.jar,\
+icu4j-*.jar,\
+jakartaee-migration-*.jar,\
+jasper-el.jar,\
+jasper.jar,\
+jaspic-api.jar,\
+jaxb-*.jar,\
+jaxen-*.jar,\
+jaxws-rt-*.jar,\
+jdom-*.jar,\
+jetty-*.jar,\
+jmx-tools.jar,\
+jmx.jar,\
+jsp-api.jar,\
+jstl.jar,\
+jta*.jar,\
+junit-*.jar,\
+junit.jar,\
+log4j*.jar,\
+mail*.jar,\
+objenesis-*.jar,\
+oraclepki.jar,\
+org.hamcrest.core_*.jar,\
+org.junit_*.jar,\
+oro-*.jar,\
+servlet-api-*.jar,\
+servlet-api.jar,\
+slf4j*.jar,\
+taglibs-standard-spec-*.jar,\
+tagsoup-*.jar,\
+tomcat-api.jar,\
+tomcat-coyote.jar,\
+tomcat-coyote-ffm.jar,\
+tomcat-dbcp.jar,\
+tomcat-i18n-*.jar,\
+tomcat-jdbc.jar,\
+tomcat-jni.jar,\
+tomcat-juli-adapters.jar,\
+tomcat-juli.jar,\
+tomcat-util-scan.jar,\
+tomcat-util.jar,\
+tomcat-websocket.jar,\
+tools.jar,\
+unboundid-ldapsdk-*.jar,\
+websocket-api.jar,\
+websocket-client-api.jar,\
+wsdl4j*.jar,\
+xercesImpl.jar,\
+xml-apis.jar,\
+xmlParserAPIs-*.jar,\
+xmlParserAPIs.jar,\
+xom-*.jar
+
+# Default list of JAR files that should be scanned that overrides the default
+# jarsToSkip list above. This is typically used to include a specific JAR that
+# has been excluded by a broad file name pattern in the jarsToSkip list.
+# The list of JARs to scan may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+tomcat.util.scan.StandardJarScanFilter.jarsToScan=\
+log4j-taglib*.jar,\
+log4j-jakarta-web*.jar,\
+log4javascript*.jar,\
+slf4j-taglib*.jar
+
+# String cache configuration.
+tomcat.util.buf.StringCache.byte.enabled=true
+#tomcat.util.buf.StringCache.char.enabled=true
+#tomcat.util.buf.StringCache.trainThreshold=500000
+#tomcat.util.buf.StringCache.cacheSize=5000
+

--- a/resources/tomcat9/catalina.properties
+++ b/resources/tomcat9/catalina.properties
@@ -1,0 +1,221 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageAccess unless the
+# corresponding RuntimePermission ("accessClassInPackage."+package) has
+# been granted.
+package.access=sun.,org.apache.catalina.,org.apache.coyote.,org.apache.jasper.,org.apache.tomcat.
+#
+# List of comma-separated packages that start with or equal this string
+# will cause a security exception to be thrown when
+# passed to checkPackageDefinition unless the
+# corresponding RuntimePermission ("defineClassInPackage."+package) has
+# been granted.
+#
+# by default, no packages are restricted for definition, and none of
+# the class loaders supplied with the JDK call checkPackageDefinition.
+#
+package.definition=sun.,java.,org.apache.catalina.,org.apache.coyote.,\
+org.apache.jasper.,org.apache.naming.,org.apache.tomcat.
+
+#
+#
+# List of comma-separated paths defining the contents of the "common"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank,the JVM system loader will be used as Catalina's "common"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values are enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+common.loader=${ADD_TO_COMMON_LOADER},"${catalina.base}/lib","${catalina.base}/lib/*.jar","${catalina.home}/lib","${catalina.home}/lib/*.jar"
+
+#
+# List of comma-separated paths defining the contents of the "server"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_HOME or CATALINA_BASE path or absolute.
+# If left as blank, the "common" loader will be used as Catalina's "server"
+# loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+server.loader=
+
+#
+# List of comma-separated paths defining the contents of the "shared"
+# classloader. Prefixes should be used to define what is the repository type.
+# Path may be relative to the CATALINA_BASE path or absolute. If left as blank,
+# the "common" loader will be used as Catalina's "shared" loader.
+# Examples:
+#     "foo": Add this folder as a class repository
+#     "foo/*.jar": Add all the JARs of the specified folder as class
+#                  repositories
+#     "foo/bar.jar": Add bar.jar as a class repository
+# Please note that for single jars, e.g. bar.jar, you need the URL form
+# starting with file:.
+#
+# Note: Values may be enclosed in double quotes ("...") in case either the
+#       ${catalina.base} path or the ${catalina.home} path contains a comma.
+#       Because double quotes are used for quoting, the double quote character
+#       may not appear in a path.
+shared.loader=
+
+# Default list of JAR files that should not be scanned using the JarScanner
+# functionality. This is typically used to scan JARs for configuration
+# information. JARs that do not contain such information may be excluded from
+# the scan to speed up the scanning process. This is the default list. JARs on
+# this list are excluded from all scans. The list must be a comma separated list
+# of JAR file names.
+# The list of JARs to skip may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+# The JARs listed below include:
+# - Tomcat Bootstrap JARs
+# - Tomcat API JARs
+# - Catalina JARs
+# - Jasper JARs
+# - Tomcat JARs
+# - Common non-Tomcat JARs
+# - Test JARs (JUnit, Cobertura and dependencies)
+tomcat.util.scan.StandardJarScanFilter.jarsToSkip=\
+annotations-api.jar,\
+ant-junit*.jar,\
+ant-launcher*.jar,\
+ant*.jar,\
+asm-*.jar,\
+aspectj*.jar,\
+bcel*.jar,\
+biz.aQute.bnd*.jar,\
+bootstrap.jar,\
+catalina-ant.jar,\
+catalina-ha.jar,\
+catalina-ssi.jar,\
+catalina-storeconfig.jar,\
+catalina-tribes.jar,\
+catalina.jar,\
+cglib-*.jar,\
+cobertura-*.jar,\
+commons-beanutils*.jar,\
+commons-codec*.jar,\
+commons-collections*.jar,\
+commons-compress*.jar,\
+commons-daemon.jar,\
+commons-dbcp*.jar,\
+commons-digester*.jar,\
+commons-fileupload*.jar,\
+commons-httpclient*.jar,\
+commons-io*.jar,\
+commons-lang*.jar,\
+commons-logging*.jar,\
+commons-math*.jar,\
+commons-pool*.jar,\
+derby-*.jar,\
+dom4j-*.jar,\
+easymock-*.jar,\
+ecj-*.jar,\
+el-api.jar,\
+geronimo-spec-jaxrpc*.jar,\
+h2*.jar,\
+ha-api-*.jar,\
+hamcrest-*.jar,\
+hibernate*.jar,\
+httpclient*.jar,\
+icu4j-*.jar,\
+jasper-el.jar,\
+jasper.jar,\
+jaspic-api.jar,\
+jaxb-*.jar,\
+jaxen-*.jar,\
+jaxws-rt-*.jar,\
+jdom-*.jar,\
+jetty-*.jar,\
+jmx-tools.jar,\
+jmx.jar,\
+jsp-api.jar,\
+jstl.jar,\
+jta*.jar,\
+junit-*.jar,\
+junit.jar,\
+log4j*.jar,\
+mail*.jar,\
+objenesis-*.jar,\
+oraclepki.jar,\
+org.hamcrest.core_*.jar,\
+org.junit_*.jar,\
+oro-*.jar,\
+servlet-api-*.jar,\
+servlet-api.jar,\
+slf4j*.jar,\
+taglibs-standard-spec-*.jar,\
+tagsoup-*.jar,\
+tomcat-api.jar,\
+tomcat-coyote.jar,\
+tomcat-coyote-ffm.jar,\
+tomcat-dbcp.jar,\
+tomcat-i18n-*.jar,\
+tomcat-jdbc.jar,\
+tomcat-jni.jar,\
+tomcat-juli-adapters.jar,\
+tomcat-juli.jar,\
+tomcat-util-scan.jar,\
+tomcat-util.jar,\
+tomcat-websocket.jar,\
+tools.jar,\
+unboundid-ldapsdk-*.jar,\
+websocket-api.jar,\
+wsdl4j*.jar,\
+xercesImpl.jar,\
+xml-apis.jar,\
+xmlParserAPIs-*.jar,\
+xmlParserAPIs.jar,\
+xom-*.jar
+
+# Default list of JAR files that should be scanned that overrides the default
+# jarsToSkip list above. This is typically used to include a specific JAR that
+# has been excluded by a broad file name pattern in the jarsToSkip list.
+# The list of JARs to scan may be over-ridden at a Context level for individual
+# scan types by configuring a JarScanner with a nested JarScanFilter.
+tomcat.util.scan.StandardJarScanFilter.jarsToScan=\
+log4j-taglib*.jar,\
+log4j-web*.jar,\
+log4javascript*.jar,\
+slf4j-taglib*.jar
+
+# String cache configuration.
+tomcat.util.buf.StringCache.byte.enabled=true
+#tomcat.util.buf.StringCache.char.enabled=true
+#tomcat.util.buf.StringCache.trainThreshold=500000
+#tomcat.util.buf.StringCache.cacheSize=5000
+
+# Disable use of some privilege blocks Tomcat doesn't need since calls to the
+# code in question are always already inside a privilege block
+org.apache.el.GET_CLASSLOADER_USE_PRIVILEGED=false
+

--- a/tomcat/base_test.go
+++ b/tomcat/base_test.go
@@ -52,6 +52,9 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.MkdirAll(filepath.Join(ctx.Buildpack.Path, "resources"), 0755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(ctx.Buildpack.Path, "resources", "tomcat9"), 0755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(ctx.Buildpack.Path, "resources", "tomcat10"), 0755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(ctx.Buildpack.Path, "resources", "tomcat11"), 0755)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "context.xml"), []byte{}, 0644)).
 			To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "logging.properties"), []byte{}, 0644)).
@@ -60,12 +63,26 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "web.xml"), []byte{}, 0644)).
 			To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "tomcat9", "catalina.properties"), []byte{}, 0644)).
+			To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "tomcat10", "catalina.properties"), []byte{}, 0644)).
+			To(Succeed())
+		Expect(os.WriteFile(filepath.Join(ctx.Buildpack.Path, "resources", "tomcat11", "catalina.properties"), []byte{}, 0644)).
+			To(Succeed())
+	})
+
+	it.Before(func() {
+		Expect(os.Setenv("BP_TOMCAT_VERSION", "10.*")).To(Succeed())
 	})
 
 	it.After(func() {
 		Expect(os.RemoveAll(ctx.Application.Path)).To(Succeed())
 		Expect(os.RemoveAll(ctx.Buildpack.Path)).To(Succeed())
 		Expect(os.RemoveAll(ctx.Layers.Path)).To(Succeed())
+	})
+
+	it.After(func() {
+		Expect(os.Unsetenv("BP_TOMCAT_VERSION")).To(Succeed())
 	})
 
 	it("contributes catalina base", func() {
@@ -128,6 +145,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(filepath.Join(layer.Path, "conf", "logging.properties")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "conf", "server.xml")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "conf", "web.xml")).To(BeARegularFile())
+		Expect(filepath.Join(layer.Path, "conf", "catalina.properties")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-access-logging-support.jar")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-lifecycle-support.jar")).To(BeARegularFile())
 		Expect(filepath.Join(layer.Path, "bin", "stub-tomcat-logging-support.jar")).To(BeARegularFile())
@@ -143,7 +161,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.Readlink(file)).To(Equal(ctx.Application.Path))
 
 		Expect(layer.LaunchEnvironment["CATALINA_BASE.default"]).To(Equal(layer.Path))
-		Expect(layer.LaunchEnvironment["CATALINA_OPTS.default"]).To(Equal("-Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource"))
+		Expect(layer.LaunchEnvironment["CATALINA_OPTS.default"]).To(Equal("-DADD_TO_COMMON_LOADER=${ADD_TO_COMMON_LOADER} -Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource"))
 	})
 
 	it("contributes custom configuration", func() {
@@ -359,6 +377,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			Expect(filepath.Join(layer.Path, "conf", "logging.properties")).To(BeARegularFile())
 			Expect(filepath.Join(layer.Path, "conf", "server.xml")).To(BeARegularFile())
 			Expect(filepath.Join(layer.Path, "conf", "web.xml")).To(BeARegularFile())
+			Expect(filepath.Join(layer.Path, "conf", "catalina.properties")).To(BeARegularFile())
 			Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-access-logging-support.jar")).To(BeARegularFile())
 			Expect(filepath.Join(layer.Path, "lib", "stub-tomcat-lifecycle-support.jar")).To(BeARegularFile())
 			Expect(filepath.Join(layer.Path, "bin", "stub-tomcat-logging-support.jar")).To(BeARegularFile())
@@ -374,7 +393,7 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.Readlink(file)).To(Equal(ctx.Application.Path))
 
 			Expect(layer.LaunchEnvironment["CATALINA_BASE.default"]).To(Equal(layer.Path))
-			Expect(layer.LaunchEnvironment["CATALINA_OPTS.default"]).To(Equal(""))
+			Expect(layer.LaunchEnvironment["CATALINA_OPTS.default"]).To(Equal("-DADD_TO_COMMON_LOADER=${ADD_TO_COMMON_LOADER}"))
 		})
 
 	})


### PR DESCRIPTION
## Summary

Add possibility to specify additional locations to be class loaded by the Tomcat common classloader. 
The default location that the Tomcat common classloader uses to classload from is the `$catalina.base/lib` folder. In order to consider additionally specified locations, the `common.loader` property in the default `catalina.properties` file is modified:
`common.loader=${ADD_TO_COMMON_LOADER},... ` in order to append extra locations for classloading by populating `ADD_TO_COMMON_LOADER`.
The modified `catalina.properties` config file is copied along with the other resource configurations on base layer contribution.
As the `catalina.properties` differs a bit in various major Tomcat releases, modified `catalina.properties` resource files are put for every major Tomcat release that [Paketo Apache Tomcat](https://github.com/paketo-buildpacks/apache-tomcat) supports currently.
`CATALINA_OPTS` default options are modified also with `-DADD_TO_COMMON_LOADER=${ADD_TO_COMMON_LOADER}` in order to reflect the additional locations specified with `ADD_TO_COMMON_LOADER` environment in the `catalina.properties` on Tomcat startup.

**Note**: If `ADD_TO_COMMON_LOADER` is not set adding an empty location to `catalina.properties` won't bother the common classloader to class load its default locations
**Note**: If `ADD_TO_COMMON_LOADER` is having an invalid folder/path specified a warning like the following will be issued on Tomcat startup:
```
12:12:03.933 [main] WARN org.apache.catalina.startup.ClassLoaderFactory -- Problem with directory [/workspace/non-existing-folder]
```
but other locations subject of the common loader won't be affected.

## Use Cases

The mechanism enables other buildpack(s) that contribute stuff in their corresponding layers and append to the `ADD_TO_COMMON_LOADER` launch env in order to specify their layer locations to be loaded by the Tomcat common classloader. This can be done by several buildpacks independently in a loosely coupled manner without knowing or appending to one external configuration package.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
