### PR TITLE
Switch to using Apache Downloads CDN

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -25,20 +25,20 @@ dependencies:
   version_pattern: "9\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
   with:
-    uri: https://archive.apache.org/dist/tomcat/tomcat-9
+    uri: https://downloads.apache.org/tomcat/tomcat-9/
 - name:            Tomcat 10.1
   id:              tomcat
   version_pattern: "10\\.1\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
   with:
-    uri: https://archive.apache.org/dist/tomcat/tomcat-10
+    uri: https://downloads.apache.org/tomcat/tomcat-10
     version_regex: "(10)\\.(1)\\.([\\d]+)"
 - name:            Tomcat 11
   id:              tomcat
   version_pattern: "11\\.[\\d]+.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
   with:
-    uri: https://archive.apache.org/dist/tomcat/tomcat-11
+    uri: https://downloads.apache.org/tomcat/tomcat-11
     version_regex: "(11)\\.([\\d]+)\\.([\\d]+)"
 - id:   tomcat-access-logging-support
   uses: docker://ghcr.io/paketo-buildpacks/actions/maven-dependency:main

--- a/.github/workflows/pb-update-tomcat-10-1.yml
+++ b/.github/workflows/pb-update-tomcat-10-1.yml
@@ -27,7 +27,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
               with:
-                uri: https://archive.apache.org/dist/tomcat/tomcat-10
+                uri: https://downloads.apache.org/tomcat/tomcat-10
                 version_regex: (10)\.(1)\.([\d]+)
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/pb-update-tomcat-11.yml
+++ b/.github/workflows/pb-update-tomcat-11.yml
@@ -27,7 +27,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
               with:
-                uri: https://archive.apache.org/dist/tomcat/tomcat-11
+                uri: https://downloads.apache.org/tomcat/tomcat-11
                 version_regex: (11)\.([\d]+)\.([\d]+)
             - name: Update Buildpack Dependency
               id: buildpack

--- a/.github/workflows/pb-update-tomcat-9.yml
+++ b/.github/workflows/pb-update-tomcat-9.yml
@@ -27,7 +27,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/tomcat-dependency:main
               with:
-                uri: https://archive.apache.org/dist/tomcat/tomcat-9
+                uri: https://downloads.apache.org/tomcat/tomcat-9/
             - name: Update Buildpack Dependency
               id: buildpack
               run: |


### PR DESCRIPTION
## Summary

The Apache Archive has become increasingly slow. This switches to using the Downloads CDN. The caveat for using Downloads is that it only has the most recent version, so buildpacks generated with these URLs will not work after the downloads have been moved off of the CDN to archives.apache.org. There is a fix for that though, and it will be documented shortly.

## Use Cases

Faster downloads.
